### PR TITLE
Assigned incorrect value

### DIFF
--- a/CloudWatchLogGroupRetentionSetter.py
+++ b/CloudWatchLogGroupRetentionSetter.py
@@ -71,7 +71,8 @@ def lambda_handler(event, context):
         while (nextToken is not None):
             response = client.describe_log_groups(nextToken=nextToken)
             nextToken = response.get('nextToken', None)
-            retention = retention.append(response['logGroups'])
+            for group in response['logGroups']:
+                retention.append(group)
  
         for group in retention:
             if 'retentionInDays' in group.keys():


### PR DESCRIPTION
Retention was set to None due to invalid assignment, now properly appends groups

*Issue #, if available:*

*Description of changes: There was an error with appending the log groups


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
